### PR TITLE
Add Jest test for NavBar mobile menu

### DIFF
--- a/__tests__/NavBar.test.tsx
+++ b/__tests__/NavBar.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import NavBar from '@/app/_components/NavBar';
+
+// Simplify next/link for testing
+jest.mock('next/link', () => ({ __esModule: true, default: (props: any) => <a {...props} /> }));
+
+describe('NavBar', () => {
+  it('toggles the mobile menu when clicking the burger icon', async () => {
+    const user = userEvent.setup();
+    const { container } = render(<NavBar />);
+
+    const menuSelector = 'div.mt-4';
+    expect(container.querySelector(menuSelector)).toBeNull();
+
+    const button = screen.getByRole('button', { name: /toggle menu/i });
+    await user.click(button);
+    expect(container.querySelector(menuSelector)).toBeInTheDocument();
+
+    await user.click(button);
+    expect(container.querySelector(menuSelector)).toBeNull();
+  });
+});

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,8 @@
+module.exports = {
+  preset: 'ts-jest',
+  testEnvironment: 'jsdom',
+  setupFilesAfterEnv: ['<rootDir>/jest.setup.ts'],
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/$1'
+  }
+};

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "lint": "next lint",
+    "test": "jest"
   },
   "dependencies": {
     "lucide-react": "^0.526.0",
@@ -19,6 +20,13 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "@types/jest": "^29.5.12",
+    "@testing-library/jest-dom": "^6.1.5",
+    "@testing-library/react": "^15.2.1",
+    "@testing-library/user-event": "^14.5.4",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.1.1",
     "tailwindcss": "^4",
     "typescript": "^5"
   }


### PR DESCRIPTION
## Summary
- add Jest and React Testing Library setup
- add a test for NavBar mobile menu toggling

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879fde63bc83209e0662b3a9f6b50f