### PR TITLE
Improve projects page layout

### DIFF
--- a/app/_components/ProjectCard.tsx
+++ b/app/_components/ProjectCard.tsx
@@ -1,0 +1,29 @@
+import React from "react";
+
+interface ProjectCardProps {
+    title: string;
+    description: string;
+    imageUrl: string;
+    technologies: string[];
+}
+
+const ProjectCard: React.FC<ProjectCardProps> = ({ title, description, imageUrl, technologies }) => {
+    return (
+        <div className="bg-[#113F67] text-white rounded-lg shadow-lg overflow-hidden">
+            <img src={imageUrl} alt="image du projet" className="w-full h-48 object-cover" />
+            <div className="p-6">
+                <h3 className="text-2xl font-bold mb-2">{title}</h3>
+                <p className="text-gray-300 mb-4">{description}</p>
+                <div className="flex flex-wrap gap-2">
+                    {technologies.map((tech) => (
+                        <span key={tech} className="bg-[#FDF5AA] text-[#113F67] text-xs font-semibold px-2 py-1 rounded-full">
+                            {tech}
+                        </span>
+                    ))}
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default ProjectCard;

--- a/app/projects/page.tsx
+++ b/app/projects/page.tsx
@@ -1,15 +1,38 @@
 import React from "react";
+import ProjectCard from "@/app/_components/ProjectCard";
+
+const projects = [
+    {
+        title: "Site e-commerce",
+        description: "Boutique en ligne réalisée avec Next.js et Stripe pour le paiement.",
+        imageUrl: "https://placehold.co/600x400",
+        technologies: ["Next.js", "Stripe", "Tailwind"],
+    },
+    {
+        title: "Application de tâches",
+        description: "Gestionnaire de tâches avec React et une API Node.js.",
+        imageUrl: "https://placehold.co/600x400",
+        technologies: ["React", "Node.js", "MongoDB"],
+    },
+    {
+        title: "Site vitrine",
+        description: "Présentation d\u2019entreprise développée sous Symfony.",
+        imageUrl: "https://placehold.co/600x400",
+        technologies: ["Symfony", "PHP", "MySQL"],
+    },
+];
 
 const Projects: React.FC = () => {
     return (
-        <div className="flex flex-col items-center justify-center h-screen">
-            <h1 className="text-4xl font-bold mb-4">Mes Projets</h1>
-            <p className="text-lg text-gray-600">
-                Voici une sélection de projets web sur lesquels j’ai travaillé, allant d’applications complexes à des sites vitrines ou e-commerce.
-            </p>
-
-        </div>
+        <section className="container mx-auto px-4 py-16">
+            <h1 className="text-4xl md:text-6xl font-bold text-center mb-12">Mes Projets</h1>
+            <div className="grid gap-8 sm:grid-cols-2 lg:grid-cols-3">
+                {projects.map((project) => (
+                    <ProjectCard key={project.title} {...project} />
+                ))}
+            </div>
+        </section>
     );
-}
+};
 
 export default Projects;


### PR DESCRIPTION
## Summary
- add `ProjectCard` component for project info
- redesign `/projects` page using a grid of cards with tech bubbles

## Testing
- `npx next lint` *(fails: interactive setup prompt)*
- `npm run build` *(fails: couldn't fetch fonts without internet)*

------
https://chatgpt.com/codex/tasks/task_e_6887a3b93bac8320b0ad23ac897e7cbb